### PR TITLE
Abstract out some SPARQL functionality.

### DIFF
--- a/src/main/scala/io/dstlr/package.scala
+++ b/src/main/scala/io/dstlr/package.scala
@@ -36,7 +36,8 @@ package object dstlr {
     val neoBatchSize = opt[Int](name = "neo4j.batch.size", default = Some(10000))
 
     // Jena
-    val jenaUri = opt[String](name = "jena.uri", default = Some("http://tuna.cs.uwaterloo.ca:9090/wikidata/query"))
+    val sparqlEndpoint = opt[String](name = "sparql.endpoint", default = Some("https://query.wikidata.org/sparql")) // Wikidata's Query Service
+//    val sparqlEndpoint = opt[String](name = "sparql.endpoint", default = Some("http://tuna.cs.uwaterloo.ca:9090/wikidata/query")) // Jena on tuna
 
     verify()
 


### PR DESCRIPTION
Previously, we depended on Jena rather than a generic SPARQL endpoint. This change allows any SPARQL endpoint to be used, defaulting to Wikidata's public one.